### PR TITLE
Datefeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ It takes 3 arguments:
     * `err` is an `Error` or `null`
     * `result` is a boolean. It will equal `true` is `addr` is the address of a Tor exit node
     
+### refreshStoreOlderThan(days, callback):
+
+This method set the maximum days elapsed before an automatic reload of the Tor node exit node list.
+* `days`: a number representing the maximum of days before an automatic reload of the Tor exit node node list.
+* `callback`: a function which signature is `function (err)` where `err` is an `Error` or `null`.
 
 ## Cookbook
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -59,12 +59,12 @@ module.exports.isInStore = function (ip, /*force,*/ cb) {
     });
 };
 
-module.exports.refreshStoreOlderThan = function (maxdays, cb) {
+module.exports.refreshStoreOlderThan = function (maxDays, cb) {
 
-    if (!Number.isInteger(maxdays)) {
-        return cb(new Error('refreshStoreOlderThan(arg) is not an integer'));
+    if (!Number.isInteger(maxDays)) {
+        return cb(new Error('maxDays must be an integer'));
     }
-    MAX_DAY_INTERVAL = maxdays;
+    MAX_DAY_INTERVAL = maxDays;
     return cb(null);
 };
 
@@ -72,8 +72,5 @@ const checkTimeInterval = function (now, lastUpdate, maxInterval) {
 
     const timeDiff = Math.abs(now.getTime() - lastUpdate.getTime());
     const diffDays = Math.floor(timeDiff / (1000 * 3600 * 24));
-    if (diffDays >= maxInterval) {
-        return true;
-    }
-    return false;
+    return diffDays >= maxInterval;
 };

--- a/lib/store.js
+++ b/lib/store.js
@@ -5,17 +5,22 @@ const Ip = require('ip');
 
 let STORE_V4 = [];
 let STORE_V6 = [];
+let LAST_UPDATE = new Date();
 
 const getStore = module.exports.getStore = function (force, cb) {
 
-    if (force || (STORE_V4.length === 0 && STORE_V6.length === 0)) {
+    if (!force) {
+        let old = checkIfLastUpdateisTooOld(LAST_UPDATE);
+    }
+    if (force || (STORE_V4.length === 0 && STORE_V6.length === 0) || old) {
         Get(URL, (err, payload) => {
 
             if (payload && !payload.list) {
                 try {
                     payload = JSON.parse(payload);
                 }
-                catch (_) {}
+                catch (_) {
+                }
             }
             if (!err && !payload.list) {
                 err = new Error('invalid response');
@@ -25,6 +30,7 @@ const getStore = module.exports.getStore = function (force, cb) {
             }
             STORE_V4 = payload.list.filter((item) => item.v === 4).map((item) => item.addr);
             STORE_V6 = payload.list.filter((item) => item.v === 6).map((item) => item.addr);
+            LAST_UPDATE = new Date(payload.date);
             return cb(null);
         });
     }
@@ -50,4 +56,16 @@ module.exports.isInStore = function (ip, /*force,*/ cb) {
         const hasV6 = !!STORE_V6.find((x) => Ip.isEqual(x, ip));
         return cb(null, hasV4 || hasV6);
     });
+};
+
+const checkIfLastUpdateisTooOld = function (lastUpdate) {
+
+    const now = new Date();
+    if (now.getYear() > lastUpdate.getYear()){
+        return true;
+    }
+    if (now.getMonth() > lastUpdate.getMonth()){
+        return true;
+    }
+    return false;
 };

--- a/lib/store.js
+++ b/lib/store.js
@@ -19,8 +19,7 @@ const getStore = module.exports.getStore = function (force, cb) {
                 try {
                     payload = JSON.parse(payload);
                 }
-                catch (_) {
-                }
+                catch (_) {}
             }
             if (!err && !payload.list) {
                 err = new Error('invalid response');

--- a/lib/store.js
+++ b/lib/store.js
@@ -6,13 +6,15 @@ const Ip = require('ip');
 let STORE_V4 = [];
 let STORE_V6 = [];
 let LAST_UPDATE = new Date();
+let MAX_DAY_INTERVAL = null;
 
 const getStore = module.exports.getStore = function (force, cb) {
 
-    if (!force) {
-        let old = checkIfLastUpdateisTooOld(LAST_UPDATE);
+    if (MAX_DAY_INTERVAL) {
+        const isOld = checkTimeInterval(new Date(), LAST_UPDATE, MAX_DAY_INTERVAL);
+        force = force || isOld;
     }
-    if (force || (STORE_V4.length === 0 && STORE_V6.length === 0) || old) {
+    if (force || (STORE_V4.length === 0 && STORE_V6.length === 0)) {
         Get(URL, (err, payload) => {
 
             if (payload && !payload.list) {
@@ -57,13 +59,20 @@ module.exports.isInStore = function (ip, /*force,*/ cb) {
     });
 };
 
-const checkIfLastUpdateisTooOld = function (lastUpdate) {
+module.exports.refreshStoreOlderThan = function (maxdays, cb) {
 
-    const now = new Date();
-    if (now.getYear() > lastUpdate.getYear()){
-        return true;
+    if (!Number.isInteger(maxdays)) {
+        return cb(new Error('refreshStoreOlderThan(arg) is not an integer'));
     }
-    if (now.getMonth() > lastUpdate.getMonth()){
+    MAX_DAY_INTERVAL = maxdays;
+    return cb(null);
+};
+
+const checkTimeInterval = function (now, lastUpdate, maxInterval) {
+
+    const timeDiff = Math.abs(now.getTime() - lastUpdate.getTime());
+    const diffDays = Math.floor(timeDiff / (1000 * 3600 * 24));
+    if (diffDays >= maxInterval) {
         return true;
     }
     return false;

--- a/test/lib/store.js
+++ b/test/lib/store.js
@@ -169,5 +169,59 @@ describe('store', () => {
                 done();
             });
         });
+
+        it('should fetch the store from the API when a given interval of day from last API call is passed', { plan: 9 }, (done) => {
+
+            const Wreck = require('wreck');
+            const now = new Date();
+            const dateInPast = now.setDate(now.getDate() - 10);
+            Wreck.get = function (url, options, cb) {
+
+                expect(url).to.equal('http://sqreen-tor.s3-website-eu-west-1.amazonaws.com/sqreen/v0/ips/tor/exit_nodes');
+                expect(options).to.equal({ headers: { accept: 'application/json' }, json: true });
+                return cb(null, { statusCode: 200 },{
+                    date: dateInPast,
+                    list: [
+                        {
+                            v: 4,
+                            addr: '127.0.0.1'
+                        },
+                        {
+                            v: 6,
+                            addr: '::1'
+                        }
+                    ]
+                });
+            };
+
+            const Store = require('../../lib/store');
+            Store.refreshStoreOlderThan(8 ,(err) => {
+
+                expect(err).to.not.exist();
+                Store.isInStore('127.0.0.1', (err, res) => {
+
+                    expect(err).to.not.exist();
+                    expect(res).to.be.true();
+                    Store.isInStore('127.0.0.2', true, (err, res2) => {
+
+                        expect(err).to.not.exist();
+                        expect(res2).to.be.false();
+                        done();
+                    });
+                });
+            });
+
+        });
+
+        it('should return an error if wrong type is passed to refreshStoreOlderThan', { plan: 1 }, (done) => {
+
+            const Store = require('../../lib/store');
+            Store.refreshStoreOlderThan('not a number',(err) => {
+
+                expect(err).to.exist();
+                done();
+            });
+
+        });
     });
 });


### PR DESCRIPTION
Hello Sqreen,
I was lurking in your repos and found this one.

Unless i missed something, if a new tor exit node appears, and the server using this lib haven't been restarted, the connections coming from it wont be refused, unless a `force` argument is given.

I was wondering if it could be a good idea to use the date you send at each API responses to make the library self aware of how long since the last IP store have been updated. 
In this PR i have made  a simple test, if the latest store refresh is 1 month old max.

Since i am not sure of the validity of this issue, i haven't adapted the test files. If you think its a good idea i can adapt them.

Vouill